### PR TITLE
support client secret

### DIFF
--- a/lib/aws/cognito_srp.rb
+++ b/lib/aws/cognito_srp.rb
@@ -59,6 +59,8 @@ module Aws
   #   aws_srp.authenticate
   #
   class CognitoSrp
+    attr_reader :user_id_for_srp
+
     NEW_PASSWORD_REQUIRED = "NEW_PASSWORD_REQUIRED"
     PASSWORD_VERIFIER = "PASSWORD_VERIFIER"
     REFRESH_TOKEN = "REFRESH_TOKEN"
@@ -118,7 +120,7 @@ module Aws
       end
 
       challenge_response = process_challenge(init_auth_response.challenge_parameters)
-
+      pp init_auth_response.challenge_parameters
       hash = @client_secret && secret_hash(@user_id_for_srp)
 
       params = {
@@ -136,10 +138,10 @@ module Aws
       auth_response.authentication_result
     end
 
-    def refresh_tokens(refresh_token)
+    def refresh_tokens(refresh_token, user_id_for_srp: @user_id_for_srp)
       auth_parameters = {
         REFRESH_TOKEN: refresh_token,
-        SECRET_HASH: @client_secret && secret_hash(@user_id_for_srp)
+        SECRET_HASH: @client_secret && secret_hash(user_id_for_srp)
       }.compact
 
       resp = @aws_client.initiate_auth(

--- a/lib/aws/cognito_srp.rb
+++ b/lib/aws/cognito_srp.rb
@@ -120,7 +120,6 @@ module Aws
       end
 
       challenge_response = process_challenge(init_auth_response.challenge_parameters)
-      pp init_auth_response.challenge_parameters
       hash = @client_secret && secret_hash(@user_id_for_srp)
 
       params = {

--- a/spec/aws/cognito_srp_spec.rb
+++ b/spec/aws/cognito_srp_spec.rb
@@ -4,8 +4,8 @@ require "aws-cognito-srp"
 
 RSpec.describe Aws::CognitoSrp do
   describe "#authenticate" do
-    it "peforms the SRP auth flow and returns the tokens" do
-      client = Aws::CognitoIdentityProvider::Client.new(
+    let(:client) do
+      Aws::CognitoIdentityProvider::Client.new(
         region: "us-west-2",
         validate_params: false,
         stub_responses: {
@@ -28,47 +28,103 @@ RSpec.describe Aws::CognitoSrp do
           }
         }
       )
+    end
 
-      aws_srp = Aws::CognitoSrp.new(
-        username:   "username",
-        password:   "password",
-        pool_id:    "us-west-2_NqkuZcXQY",
-        client_id:  "4l9rvl4mv5es1eep1qe97cautn",
-        aws_client: client
-      )
+    context 'when client_secret is not provided' do
+      let(:aws_srp) do
+        Aws::CognitoSrp.new(
+          username:   "username",
+          password:   "password",
+          pool_id:    "us-west-2_NqkuZcXQY",
+          client_id:  "4l9rvl4mv5es1eep1qe97cautn",
+          aws_client: client
+        )
+      end
 
-      tokens = aws_srp.authenticate
+      it "peforms the SRP auth flow and returns the tokens" do
+        tokens = aws_srp.authenticate
 
-      expect(tokens.id_token).to eq('dummy_id_token')
-      expect(tokens.access_token).to eq('dummy_access_token')
-      expect(tokens.refresh_token).to eq('dummy_refresh_token')
+        expect(tokens.id_token).to eq('dummy_id_token')
+        expect(tokens.access_token).to eq('dummy_access_token')
+        expect(tokens.refresh_token).to eq('dummy_refresh_token')
 
-      expect(client.api_requests.first).to include(
-        operation_name: :initiate_auth,
-        params: hash_including(
-          auth_flow: "USER_SRP_AUTH",
-          auth_parameters: hash_including(
-            "USERNAME" => "username",
-            "SRP_A" => a_string_matching(/[0-9a-f]+/),
+        expect(client.api_requests.first).to include(
+          operation_name: :initiate_auth,
+          params: hash_including(
+            auth_flow: "USER_SRP_AUTH",
+            auth_parameters: hash_including(
+              "USERNAME" => "username",
+              "SRP_A" => a_string_matching(/[0-9a-f]+/),
+            )
           )
         )
-      )
 
-      # Matches a non-empty Base64 string
-      b64_re = %r<^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=|[A-Za-z0-9+/]{4})$>
+        # Matches a non-empty Base64 string
+        b64_re = %r<^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=|[A-Za-z0-9+/]{4})$>
 
-      expect(client.api_requests[1]).to include(
-        operation_name: :respond_to_auth_challenge,
-        params: hash_including(
-          challenge_name: "PASSWORD_VERIFIER",
-          challenge_responses: hash_including(
-            "TIMESTAMP" => a_string_matching(/^[A-Z][a-z]{2} [A-Z][a-z]{2} \d\d? \d\d:\d\d:\d\d UTC \d{4,}$/),
-            "USERNAME" => "DUMMY_USER_ID_FOR_SRP",
-            "PASSWORD_CLAIM_SECRET_BLOCK" => a_string_matching(b64_re),
-            "PASSWORD_CLAIM_SIGNATURE" => a_string_matching(b64_re)
+        expect(client.api_requests[1]).to include(
+          operation_name: :respond_to_auth_challenge,
+          params: hash_including(
+            challenge_name: "PASSWORD_VERIFIER",
+            challenge_responses: hash_including(
+              "TIMESTAMP" => a_string_matching(/^[A-Z][a-z]{2} [A-Z][a-z]{2} \d\d? \d\d:\d\d:\d\d UTC \d{4,}$/),
+              "USERNAME" => "DUMMY_USER_ID_FOR_SRP",
+              "PASSWORD_CLAIM_SECRET_BLOCK" => a_string_matching(b64_re),
+              "PASSWORD_CLAIM_SIGNATURE" => a_string_matching(b64_re)
+            )
           )
         )
-      )
+      end
+    end
+
+    context 'when client_secret is provided' do
+      let(:aws_srp) do
+        Aws::CognitoSrp.new(
+          username:   "username",
+          password:   "password",
+          pool_id:    "us-west-2_NqkuZcXQY",
+          client_id:  "4l9rvl4mv5es1eep1qe97cautn",
+          aws_client: client,
+          client_secret: "client-secret"
+        )
+      end
+
+      it "peforms the SRP auth flow and returns the tokens" do
+        tokens = aws_srp.authenticate
+
+        expect(tokens.id_token).to eq('dummy_id_token')
+        expect(tokens.access_token).to eq('dummy_access_token')
+        expect(tokens.refresh_token).to eq('dummy_refresh_token')
+
+        # Matches a non-empty Base64 string
+        b64_re = %r<^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=|[A-Za-z0-9+/]{4})$>
+
+        expect(client.api_requests.first).to include(
+          operation_name: :initiate_auth,
+          params: hash_including(
+            auth_flow: "USER_SRP_AUTH",
+            auth_parameters: hash_including(
+              "USERNAME" => "username",
+              "SRP_A" => a_string_matching(/[0-9a-f]+/),
+              "SECRET_HASH" => a_string_matching(b64_re),
+            )
+          )
+        )
+
+        expect(client.api_requests[1]).to include(
+          operation_name: :respond_to_auth_challenge,
+          params: hash_including(
+            challenge_name: "PASSWORD_VERIFIER",
+            challenge_responses: hash_including(
+              "TIMESTAMP" => a_string_matching(/^[A-Z][a-z]{2} [A-Z][a-z]{2} \d\d? \d\d:\d\d:\d\d UTC \d{4,}$/),
+              "USERNAME" => "DUMMY_USER_ID_FOR_SRP",
+              "PASSWORD_CLAIM_SECRET_BLOCK" => a_string_matching(b64_re),
+              "PASSWORD_CLAIM_SIGNATURE" => a_string_matching(b64_re),
+              "SECRET_HASH" => a_string_matching(b64_re),
+            )
+          )
+        )
+      end
     end
   end
 


### PR DESCRIPTION
refs #1.

This PR is for supporting client secret.
The client_secret of `Aws::CognitoSrp.new` is optional argument. 
And it keeps same behavior if client_secret is not specified.

```ruby
require "aws-cognito-srp"

aws_srp = Aws::CognitoSrp.new(
  username:   "username",
  password:   "password",
  pool_id:    "pool-id",
  client_id:  "client-id",
  aws_client: Aws::CognitoIdentityProvider::Client.new(region: "aws-region"),
  client_secret: "client_secret" # this is optional
)
```

