### PR TITLE
[WIP] Add Ruby 3.4.0-preview1 to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,14 +8,14 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
-        ruby: [2.4, 2.5, 2.6, 2.7, '3.0', 3.1, 3.2, 3.3, jruby, truffleruby]
+        ruby: [2.7, '3.0', 3.1, 3.2, 3.3, '3.4.0-preview1', jruby, truffleruby]
 
     runs-on: ${{ matrix.os }}
 
     name: Test against ${{ matrix.ruby }} on ${{ matrix.os }}
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ signatures:
 
 ## Supported rubies
 
-This gem is tested against and supports Ruby 2.4 through 3.3, JRuby and
+This gem is tested against and supports Ruby 2.7 through 3.3, JRuby and
 TruffleRuby.
 
 ## Development


### PR DESCRIPTION
Currently failing because aws-sdk-ruby uses `Base64` without requiring the base64 gem as a dependency (removed from the stdlib in Ruby 3.4).

See: https://github.com/aws/aws-sdk-ruby/issues/2984